### PR TITLE
Enable Fiori UI annotations

### DIFF
--- a/cap_ui/db/schema.cds
+++ b/cap_ui/db/schema.cds
@@ -1,6 +1,24 @@
 namespace db;
 
+@Capabilities.InsertRestrictions.Insertable : true
+@Capabilities.UpdateRestrictions.Updatable   : true
+@Capabilities.DeleteRestrictions.Deletable   : true
+@UI: {
+  HeaderInfo: {
+    TypeNamePlural: 'OData Services',
+    TypeName      : 'OData Service',
+    Title         : { Value: service_url }
+  },
+  LineItem: [
+    { Value: service_url,   Label: 'Service URL' },
+    { Value: version_hash,  Label: 'Version Hash' },
+    { Value: active,        Label: 'Active' },
+    { Value: created_at,    Label: 'Created At' },
+    { Value: last_updated,  Label: 'Last Updated' }
+  ]
+}
 entity ODataServices {
+  @UI.Hidden
   key ID           : UUID;
   service_url      : String;
   metadata_json    : LargeString;

--- a/cap_ui/srv/service.cds
+++ b/cap_ui/srv/service.cds
@@ -1,5 +1,6 @@
 using { db as my } from '../db/schema';
 
 service AdminService {
+  @odata.draft.enabled
   entity ODataServices as projection on my.ODataServices;
 }


### PR DESCRIPTION
## Summary
- annotate ODataServices with common UI annotations for Fiori Elements
- expose AdminService entity as draft-enabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ca2c1dda4832bb4025726bf3a03b9