### PR TITLE
Add service metadata update logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+package-lock.json
+__pycache__/
+*/__pycache__/
+pytest_cache/
+*.sqlite

--- a/cap_ui/srv/admin-service.js
+++ b/cap_ui/srv/admin-service.js
@@ -1,0 +1,19 @@
+const crypto = require('crypto');
+
+module.exports = srv => {
+  const { ODataServices } = srv.entities;
+
+  function computeHash(data) {
+    return crypto.createHash('md5').update(data).digest('hex');
+  }
+
+  srv.before(['CREATE', 'UPDATE'], ODataServices, req => {
+    if (req.data.metadata_json) {
+      req.data.version_hash = computeHash(req.data.metadata_json);
+    }
+    req.data.last_updated = new Date();
+    if (req.event === 'CREATE' && !req.data.created_at) {
+      req.data.created_at = new Date();
+    }
+  });
+};


### PR DESCRIPTION
## Summary
- ignore typical build and cache files
- auto-update `version_hash`, `created_at`, and `last_updated` when services are created or updated

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ca91bd0e8832ba62c4b9099f00165