### PR TITLE
Implement metadata refresh and improve schema

### DIFF
--- a/cap_ui/db/schema.cds
+++ b/cap_ui/db/schema.cds
@@ -11,17 +11,31 @@ namespace db;
   },
   LineItem: [
     { Value: service_url,   Label: 'Service URL' },
+    { Value: odata_version, Label: 'OData Version' },
     { Value: version_hash,  Label: 'Version Hash' },
     { Value: active,        Label: 'Active' },
     { Value: created_at,    Label: 'Created At' },
     { Value: last_updated,  Label: 'Last Updated' }
+  ],
+  Identification: [
+    { Value: version_hash,  Label: 'Version Hash' },
+    { Value: active,        Label: 'Active' },
+    { Value: created_at,    Label: 'Created At' },
+    { Value: last_updated,  Label: 'Last Updated' },
+    { Value: odata_version, Label: 'OData Version' }
   ]
 }
 entity ODataServices {
   @UI.Hidden
   key ID           : UUID;
   service_url      : String;
+  @UI.Hidden
   metadata_json    : LargeString;
+  @UI.Identification
+  @UI.LineItem
+  odata_version    : String;
+  @UI.Identification
+  @UI.LineItem
   version_hash     : String;
   active           : Boolean default true;
   created_at       : Timestamp;

--- a/cap_ui/package.json
+++ b/cap_ui/package.json
@@ -8,6 +8,8 @@
   },
   "dependencies": {
     "@sap/cds": "^7",
-    "sqlite3": "^5"
+    "sqlite3": "^5",
+    "node-fetch": "^2",
+    "xml2js": "^0.6"
   }
 }

--- a/cap_ui/srv/admin-service.js
+++ b/cap_ui/srv/admin-service.js
@@ -1,4 +1,8 @@
+const cds = require('@sap/cds');
+const { SELECT, UPDATE } = cds;
 const crypto = require('crypto');
+const fetch = require('node-fetch');
+const xml2js = require('xml2js');
 
 module.exports = srv => {
   const { ODataServices } = srv.entities;
@@ -15,5 +19,33 @@ module.exports = srv => {
     if (req.event === 'CREATE' && !req.data.created_at) {
       req.data.created_at = new Date();
     }
+  });
+
+  async function fetchMetadata(url) {
+    const metaUrl = url.replace(/\/$/, '') + '/$metadata';
+    const res = await fetch(metaUrl);
+    const xml = await res.text();
+    const match = xml.match(/<edmx:Edmx[^>]*Version="([^"]+)"/i);
+    const version = match && match[1].startsWith('4') ? 'v4' : 'v2';
+    const parsed = await xml2js.parseStringPromise(xml, { explicitArray: false });
+    return { json: JSON.stringify(parsed), version };
+  }
+
+  srv.on('refreshMetadata', async req => {
+    const { ID } = req.params[0];
+    const srvTx = srv.tx(req);
+    const service = await srvTx.run(SELECT.one.from(ODataServices).where({ ID }));
+    if (!service) return req.error(404, 'Service not found');
+    const { json, version } = await fetchMetadata(service.service_url);
+    const versionHash = computeHash(json);
+    await srvTx.run(
+      UPDATE(ODataServices, ID).set({
+        metadata_json: json,
+        version_hash: versionHash,
+        odata_version: version,
+        last_updated: new Date()
+      })
+    );
+    return srvTx.run(SELECT.one.from(ODataServices).where({ ID }));
   });
 };

--- a/cap_ui/srv/service.cds
+++ b/cap_ui/srv/service.cds
@@ -2,5 +2,7 @@ using { db as my } from '../db/schema';
 
 service AdminService {
   @odata.draft.enabled
-  entity ODataServices as projection on my.ODataServices;
+  entity ODataServices as projection on my.ODataServices {
+    action refreshMetadata();
+  };
 }

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -8,6 +8,7 @@ def create_schema(conn):
         service_url TEXT NOT NULL,
         metadata_json TEXT,
         version_hash TEXT,
+        odata_version TEXT,
         active INTEGER DEFAULT 1,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -25,6 +26,7 @@ def test_schema_columns():
         "service_url",
         "metadata_json",
         "version_hash",
+        "odata_version",
         "active",
         "created_at",
         "last_updated",


### PR DESCRIPTION
## Summary
- add `odata_version` field and hide metadata from UI list
- expose refreshMetadata action in AdminService
- implement logic to fetch metadata and store its version
- update package dependencies
- adjust database schema test

## Testing
- `pip install -r fastapi_backend/requirements.txt`
- `pip install httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cb1ef5820832bac1d38597f76d1be