### PR TITLE
Fix metadata refresh and toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,11 @@ Install `pytest` and required packages then execute the tests:
 pip install -r fastapi_backend/requirements.txt pytest
 pytest -q
 ```
+
+## Demo OData Service
+
+For a quick test use the public Northwind OData endpoint. Create a new record in
+the CAP admin UI with the service URL
+`https://services.odata.org/northwind/northwind.svc/` and execute the
+`refreshMetadata` action. The metadata JSON will be stored in the database and
+the `odata_version` column will indicate whether the service is v2 or v4.

--- a/cap_ui/db/schema.cds
+++ b/cap_ui/db/schema.cds
@@ -26,10 +26,10 @@ namespace db;
   ]
 }
 entity ODataServices {
-  @UI.Hidden
+  @UI.Hidden: true
   key ID           : UUID;
   service_url      : String;
-  @UI.Hidden
+  @UI.Hidden: true
   metadata_json    : LargeString;
   @UI.Identification
   @UI.LineItem
@@ -40,4 +40,8 @@ entity ODataServices {
   active           : Boolean default true;
   created_at       : Timestamp;
   last_updated     : Timestamp;
+  actions {
+    action refreshMetadata();
+    action toggleActive();
+  }
 }

--- a/cap_ui/srv/admin-service.js
+++ b/cap_ui/srv/admin-service.js
@@ -11,7 +11,16 @@ module.exports = srv => {
     return crypto.createHash('md5').update(data).digest('hex');
   }
 
-  srv.before(['CREATE', 'UPDATE'], ODataServices, req => {
+  srv.before(['CREATE', 'UPDATE'], ODataServices, async req => {
+    if (req.data.service_url && !req.data.metadata_json) {
+      try {
+        const { json, version } = await fetchMetadata(req.data.service_url);
+        req.data.metadata_json = json;
+        req.data.odata_version = version;
+      } catch (e) {
+        req.warn('Failed to fetch metadata');
+      }
+    }
     if (req.data.metadata_json) {
       req.data.version_hash = computeHash(req.data.metadata_json);
     }
@@ -43,6 +52,20 @@ module.exports = srv => {
         metadata_json: json,
         version_hash: versionHash,
         odata_version: version,
+        last_updated: new Date()
+      })
+    );
+    return srvTx.run(SELECT.one.from(ODataServices).where({ ID }));
+  });
+
+  srv.on('toggleActive', async req => {
+    const { ID } = req.params[0];
+    const srvTx = srv.tx(req);
+    const service = await srvTx.run(SELECT.one.from(ODataServices).where({ ID }));
+    if (!service) return req.error(404, 'Service not found');
+    await srvTx.run(
+      UPDATE(ODataServices, ID).set({
+        active: !service.active,
         last_updated: new Date()
       })
     );

--- a/cap_ui/srv/service.cds
+++ b/cap_ui/srv/service.cds
@@ -2,9 +2,8 @@ using { db as my } from '../db/schema';
 
 service AdminService {
   @odata.draft.enabled
-  entity ODataServices as projection on my.ODataServices ;
-
- 
-  action refreshMetadata();
- 
+  entity ODataServices as projection on my.ODataServices {
+    action refreshMetadata();
+    action toggleActive();
+  };
 }


### PR DESCRIPTION
## Summary
- hide internal fields in CAP schema
- bind actions to ODataServices entity
- auto fetch metadata on create/update
- add toggleActive action
- document how to use the Northwind demo service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce383dfcc832b86587f660f147e31