### PR TITLE
Fix metadata refresh and update handling

### DIFF
--- a/cap_ui/db/schema.cds
+++ b/cap_ui/db/schema.cds
@@ -9,6 +9,11 @@ namespace db;
     TypeName      : 'OData Service',
     Title         : { Value: service_url }
   },
+  Facets: [{
+      $Type : 'UI.ReferenceFacet',
+      Label : 'Details',
+      Target: '@UI.Identification'
+  }],
   LineItem: [
     { Value: service_url,   Label: 'Service URL' },
     { Value: odata_version, Label: 'OData Version' },

--- a/cap_ui/srv/admin-service.js
+++ b/cap_ui/srv/admin-service.js
@@ -11,7 +11,29 @@ module.exports = srv => {
     return crypto.createHash('md5').update(data).digest('hex');
   }
 
-  srv.before(['CREATE', 'UPDATE'], ODataServices, req => {
+  async function fetchMetadata(url) {
+    const metaUrl = url.replace(/\/$/, '') + '/$metadata';
+    const res = await fetch(metaUrl);
+    if (!res.ok) {
+      throw new Error(`Failed to fetch metadata from ${metaUrl}`);
+    }
+    const xml = await res.text();
+    const match = xml.match(/<edmx:Edmx[^>]*Version="([^"]+)"/i);
+    const version = match && match[1].startsWith('4') ? 'v4' : 'v2';
+    const parsed = await xml2js.parseStringPromise(xml, { explicitArray: false });
+    return { json: JSON.stringify(parsed), version };
+  }
+
+  srv.before(['CREATE', 'UPDATE'], ODataServices, async req => {
+    if (!req.data.metadata_json && req.data.service_url) {
+      try {
+        const { json, version } = await fetchMetadata(req.data.service_url);
+        req.data.metadata_json = json;
+        req.data.odata_version = version;
+      } catch (e) {
+        req.warn(`Failed to fetch metadata: ${e.message}`);
+      }
+    }
     if (req.data.metadata_json) {
       req.data.version_hash = computeHash(req.data.metadata_json);
     }
@@ -21,31 +43,25 @@ module.exports = srv => {
     }
   });
 
-  async function fetchMetadata(url) {
-    const metaUrl = url.replace(/\/$/, '') + '/$metadata';
-    const res = await fetch(metaUrl);
-    const xml = await res.text();
-    const match = xml.match(/<edmx:Edmx[^>]*Version="([^"]+)"/i);
-    const version = match && match[1].startsWith('4') ? 'v4' : 'v2';
-    const parsed = await xml2js.parseStringPromise(xml, { explicitArray: false });
-    return { json: JSON.stringify(parsed), version };
-  }
-
   srv.on('refreshMetadata', async req => {
     const { ID } = req.params[0];
-    const srvTx = srv.tx(req);
-    const service = await srvTx.run(SELECT.one.from(ODataServices).where({ ID }));
+    const tx = srv.tx(req);
+    const service = await tx.run(SELECT.one.from(ODataServices).where({ ID }));
     if (!service) return req.error(404, 'Service not found');
-    const { json, version } = await fetchMetadata(service.service_url);
-    const versionHash = computeHash(json);
-    await srvTx.run(
-      UPDATE(ODataServices, ID).set({
-        metadata_json: json,
-        version_hash: versionHash,
-        odata_version: version,
-        last_updated: new Date()
-      })
-    );
-    return srvTx.run(SELECT.one.from(ODataServices).where({ ID }));
+    try {
+      const { json, version } = await fetchMetadata(service.service_url);
+      const versionHash = computeHash(json);
+      await tx.run(
+        UPDATE(ODataServices, ID).set({
+          metadata_json: json,
+          version_hash: versionHash,
+          odata_version: version,
+          last_updated: new Date()
+        })
+      );
+      return tx.run(SELECT.one.from(ODataServices).where({ ID }));
+    } catch (e) {
+      return req.error(500, e.message);
+    }
   });
 };

--- a/cap_ui/srv/service.cds
+++ b/cap_ui/srv/service.cds
@@ -2,9 +2,7 @@ using { db as my } from '../db/schema';
 
 service AdminService {
   @odata.draft.enabled
-  entity ODataServices as projection on my.ODataServices ;
-
- 
-  action refreshMetadata();
- 
+  entity ODataServices as projection on my.ODataServices {
+    action refreshMetadata();
+  };
 }


### PR DESCRIPTION
## Summary
- show details facet in annotation for object page
- expose `refreshMetadata` as an entity action
- auto fetch metadata when creating or updating services
- handle fetching errors and compute `odata_version`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce383dfcc832b86587f660f147e31