### PR TITLE
Improve metadata handling for services

### DIFF
--- a/cap_ui/db/schema.cds
+++ b/cap_ui/db/schema.cds
@@ -15,7 +15,12 @@ namespace db;
     { Value: version_hash,  Label: 'Version Hash' },
     { Value: active,        Label: 'Active' },
     { Value: created_at,    Label: 'Created At' },
-    { Value: last_updated,  Label: 'Last Updated' }
+    { Value: last_updated,  Label: 'Last Updated' },
+    {
+      $Type  : 'UI.DataFieldForAction',
+      Action : 'AdminService.ODataServices_refreshMetadata',
+      Label  : 'Refresh Metadata'
+    }
   ],
   Identification: [
     { Value: version_hash,  Label: 'Version Hash' },

--- a/cap_ui/srv/service.cds
+++ b/cap_ui/srv/service.cds
@@ -2,9 +2,7 @@ using { db as my } from '../db/schema';
 
 service AdminService {
   @odata.draft.enabled
-  entity ODataServices as projection on my.ODataServices ;
-
- 
-  action refreshMetadata();
- 
+  entity ODataServices as projection on my.ODataServices {
+    action refreshMetadata();
+  };
 }


### PR DESCRIPTION
## Summary
- bind refreshMetadata action to `ODataServices`
- expose Refresh Metadata button via UI annotations
- populate metadata, version, timestamps in more events

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce383dfcc832b86587f660f147e31