### PR TITLE
Add auth and split service URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,13 @@ pip install -r fastapi_backend/requirements.txt pytest
 pytest -q
 ```
 
+Create a `.env` file in `fastapi_backend` with `SAP_USER` and `SAP_PASS` to use
+basic authentication when fetching remote metadata.
+
 ## Demo OData Service
 
 For a quick test use the public Northwind OData endpoint. Create a new record in
-the CAP admin UI with the service URL
-`https://services.odata.org/northwind/northwind.svc/` and execute the
-`refreshMetadata` action. The metadata JSON will be stored in the database and
-the `odata_version` column will indicate whether the service is v2 or v4.
+the CAP admin UI with `base_url` set to `https://services.odata.org` and
+`service_name` to `northwind/northwind.svc`. After executing the
+`refreshMetadata` action the metadata JSON will be stored in the database and the
+`odata_version` column will indicate whether the service is v2 or v4.

--- a/cap_ui/db/schema.cds
+++ b/cap_ui/db/schema.cds
@@ -7,7 +7,7 @@ namespace db;
   HeaderInfo: {
     TypeNamePlural: 'OData Services',
     TypeName      : 'OData Service',
-    Title         : { Value: service_url }
+    Title         : { Value: service_name }
   },
   Facets: [{
       $Type : 'UI.ReferenceFacet',
@@ -15,7 +15,8 @@ namespace db;
       Target: '@UI.Identification'
   }],
   LineItem: [
-    { Value: service_url,   Label: 'Service URL' },
+    { Value: base_url,      Label: 'Base URL' },
+    { Value: service_name,  Label: 'Service Name' },
     { Value: odata_version, Label: 'OData Version' },
     { Value: active,        Label: 'Active' },
     { Value: created_at,    Label: 'Created At' },
@@ -36,7 +37,8 @@ namespace db;
 entity ODataServices {
   @UI.Hidden: true
   key ID           : UUID;
-  service_url      : String;
+  base_url         : String;
+  service_name     : String;
   @UI.Hidden: true
   metadata_json    : LargeString;
   @UI.Identification

--- a/cap_ui/package.json
+++ b/cap_ui/package.json
@@ -10,7 +10,8 @@
     "@sap/cds": "^7",
     "sqlite3": "^5",
     "node-fetch": "^2",
-    "xml2js": "^0.6"
+    "xml2js": "^0.6",
+    "dotenv": "^16"
   },
   "cds": {
     "requires": {

--- a/cap_ui/srv/admin-service.js
+++ b/cap_ui/srv/admin-service.js
@@ -2,9 +2,17 @@ const cds = require('@sap/cds');
 const { SELECT, UPDATE } = cds;
 const fetch = require('node-fetch');
 const xml2js = require('xml2js');
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '../../fastapi_backend/.env') });
 
-async function fetchMetadata(serviceUrl) {
-  const res = await fetch(`${serviceUrl.replace(/\/$/, '')}/$metadata`);
+async function fetchMetadata(baseUrl, serviceName) {
+  const url = `${baseUrl.replace(/\/$/, '')}/${serviceName.replace(/^\//, '')}/$metadata`;
+  const user = process.env.SAP_USER;
+  const pass = process.env.SAP_PASS;
+  const headers = user && pass ? {
+    Authorization: 'Basic ' + Buffer.from(`${user}:${pass}`).toString('base64')
+  } : {};
+  const res = await fetch(url, { headers });
   if (!res.ok) throw new Error(`Failed to fetch metadata: ${res.statusText}`);
   const xml = await res.text();
   const json = JSON.stringify(await xml2js.parseStringPromise(xml));
@@ -31,12 +39,12 @@ module.exports = srv => {
 
 
   srv.before(['CREATE', 'UPDATE', 'NEW', 'PATCH'], ODataServices, async req => {
-    if (!req.data.metadata_json && req.data.service_url) {
-      const { json, version } = await fetchMetadata(req.data.service_url);
+    if (!req.data.metadata_json && req.data.base_url && req.data.service_name) {
+      const { json, version } = await fetchMetadata(req.data.base_url, req.data.service_name);
       req.data.metadata_json = json;
       req.data.odata_version = version;
     }
-    if (req.data.metadata_json && !req.data.service_url) {
+    if (req.data.metadata_json && !(req.data.base_url && req.data.service_name)) {
       // metadata_json provided directly
       const parsed = await parseVersion(req.data.metadata_json);
       if (parsed) req.data.odata_version = parsed;
@@ -53,7 +61,7 @@ module.exports = srv => {
     const service = await tx.run(SELECT.one.from(ODataServices).where({ ID }));
     if (!service) return req.error(404, 'Service not found');
     try {
-      const { json, version } = await fetchMetadata(service.service_url);
+      const { json, version } = await fetchMetadata(service.base_url, service.service_name);
       await tx.run(
         UPDATE(ODataServices, ID).set({
           metadata_json: json,
@@ -61,6 +69,7 @@ module.exports = srv => {
           last_updated: new Date()
         })
       );
+      req.info('Metadata refreshed successfully');
       return tx.run(SELECT.one.from(ODataServices).where({ ID }));
     } catch (e) {
       return req.error(500, e.message);
@@ -73,7 +82,7 @@ module.exports = srv => {
     const service = await tx.run(SELECT.one.from(ODataServices).where({ ID }));
     if (!service) return req.error(404, 'Service not found');
     try {
-      const { json, version } = await fetchMetadata(service.service_url);
+      const { json, version } = await fetchMetadata(service.base_url, service.service_name);
       await tx.run(
         UPDATE(ODataServices, ID).set({
           metadata_json: json,
@@ -81,6 +90,7 @@ module.exports = srv => {
           last_updated: new Date()
         })
       );
+      req.info('Service reactivated with latest metadata');
       return tx.run(SELECT.one.from(ODataServices).where({ ID }));
     } catch (e) {
       return req.error(500, e.message);

--- a/fastapi_backend/endpoint_generator.py
+++ b/fastapi_backend/endpoint_generator.py
@@ -16,7 +16,8 @@ def generate_routers(services: Iterable[dict]) -> Iterable[APIRouter]:
     routers = []
     for svc in services:
         meta = parse_metadata(svc.get("metadata_json", "{}"))
-        router = APIRouter(prefix=f"/{svc['service_url'].strip('/')}")
+        prefix = f"/{svc['service_name'].strip('/')}"
+        router = APIRouter(prefix=prefix)
         for entity in meta.get("entities", []):
             route = _create_list_route(entity["name"])
             router.add_api_route(
@@ -24,7 +25,7 @@ def generate_routers(services: Iterable[dict]) -> Iterable[APIRouter]:
                 route,
                 methods=["GET"],
                 summary=f"List {entity['name']}",
-                tags=[svc["service_url"]],
+                tags=[svc["service_name"]],
             )
         routers.append(router)
     return routers

--- a/fastapi_backend/metadata_store.py
+++ b/fastapi_backend/metadata_store.py
@@ -10,7 +10,7 @@ class MetadataStore:
         conn = sqlite3.connect(self.db_path)
         conn.row_factory = sqlite3.Row
         cur = conn.execute(
-            "SELECT service_url, metadata_json FROM odata_services WHERE active = 1"
+            "SELECT base_url, service_name, metadata_json FROM odata_services WHERE active = 1"
         )
         rows = [dict(row) for row in cur.fetchall()]
         conn.close()

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -5,7 +5,8 @@ def create_schema(conn):
     conn.execute("""
     CREATE TABLE IF NOT EXISTS odata_services (
         id TEXT PRIMARY KEY,
-        service_url TEXT NOT NULL,
+        base_url TEXT NOT NULL,
+        service_name TEXT NOT NULL,
         metadata_json TEXT,
         odata_version TEXT,
         active INTEGER DEFAULT 1,
@@ -22,7 +23,8 @@ def test_schema_columns():
     columns = {row[1] for row in cursor.fetchall()}
     expected = {
         "id",
-        "service_url",
+        "base_url",
+        "service_name",
         "metadata_json",
         "odata_version",
         "active",

--- a/tests/test_fastapi_openapi.py
+++ b/tests/test_fastapi_openapi.py
@@ -17,14 +17,15 @@ def setup_db(path: str):
     conn.execute(
         """CREATE TABLE odata_services (
             id TEXT,
-            service_url TEXT,
+            base_url TEXT,
+            service_name TEXT,
             metadata_json TEXT,
             active INTEGER
         )"""
     )
     conn.execute(
-        "INSERT INTO odata_services VALUES (?,?,?,1)",
-        ("1", "demo", SAMPLE_METADATA),
+        "INSERT INTO odata_services VALUES (?,?,?,?,1)",
+        ("1", "root", "demo", SAMPLE_METADATA),
     )
     conn.commit()
     conn.close()


### PR DESCRIPTION
## Summary
- split `service_url` into `base_url` and `service_name`
- construct metadata URL from new fields and use basic auth
- store JSON metadata correctly and show success info to UI
- adjust FastAPI backend and tests for new columns
- document `.env` usage and new example

## Testing
- `pip install -r fastapi_backend/requirements.txt pytest`
- `pip install httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf0ced334832b96e9fd13682ec742