### PR TITLE
Improve metadata refresh logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ pip install -r fastapi_backend/requirements.txt pytest
 pytest -q
 ```
 
-Create a `.env` file in `fastapi_backend` with `SAP_USER` and `SAP_PASS` to use
-basic authentication when fetching remote metadata.
+Create `.env` files in both `fastapi_backend` and `cap_ui` containing `SAP_USER`
+and `SAP_PASS` to enable basic authentication when retrieving remote
+metadata.
 
 ## Demo OData Service
 

--- a/cap_ui/srv/admin-service.js
+++ b/cap_ui/srv/admin-service.js
@@ -76,28 +76,44 @@ module.exports = srv => {
   });
 
   srv.on('refreshMetadata', async req => {
-    const { ID } = req.params[0];
+    const ids =
+      (Array.isArray(req.data?.IDs) && req.data.IDs) ||
+      (Array.isArray(req.params) && req.params.map(p => p.ID)) ||
+      [];
+    if (!ids.length && req.params?.[0]?.ID) ids.push(req.params[0].ID);
+    if (!ids.length) return req.error(400, 'No service IDs provided');
+
     const tx = srv.tx(req);
-    const service = await tx.run(SELECT.one.from(ODataServices).where({ ID }));
-    if (!service) return req.error(404, 'Service not found');
-    try {
-      const { json, version } = await fetchMetadata(
-        service.service_base_url,
-        service.service_name
-      );
-      await tx.run(
-        UPDATE(ODataServices, ID).set({
-          metadata_json: json,
-          odata_version: version,
-          last_updated: new Date()
-        })
-      );
-      req.info('Metadata refreshed successfully');
-      return tx.run(SELECT.one.from(ODataServices).where({ ID }));
-    } catch (e) {
-      req.error(500, e.message);
-      return;
+    const results = [];
+
+    for (const ID of ids) {
+      const service = await tx.run(SELECT.one.from(ODataServices).where({ ID }));
+      if (!service) {
+        req.error(`Service not found for ID ${ID}`);
+        results.push({ ID, status: 'failed', message: 'Service not found' });
+        continue;
+      }
+      try {
+        const { json, version } = await fetchMetadata(
+          service.service_base_url,
+          service.service_name
+        );
+        await tx.run(
+          UPDATE(ODataServices, ID).set({
+            metadata_json: json,
+            odata_version: version,
+            last_updated: new Date()
+          })
+        );
+        req.info(`Metadata refreshed for ${service.service_name}`);
+        results.push({ ID, status: 'success' });
+      } catch (e) {
+        req.error(e.message);
+        results.push({ ID, status: 'failed', message: e.message });
+      }
     }
+
+    return results;
   });
 
   srv.on('toggleActive', async req => {


### PR DESCRIPTION
## Summary
- document `.env` usage for both services
- support multiple service IDs when refreshing metadata

## Testing
- `pip install -r fastapi_backend/requirements.txt pytest`
- `pip install httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d13c9d7d8832ba6880f9809cf6cea