### PR TITLE
Move refresh metadata action to detail view

### DIFF
--- a/cap_ui/db/schema.cds
+++ b/cap_ui/db/schema.cds
@@ -20,13 +20,7 @@ namespace db;
     { Value: odata_version,    Label: 'OData Version' },
     { Value: active,        Label: 'Active' },
     { Value: created_at,    Label: 'Created At' },
-    { Value: last_updated,  Label: 'Last Updated' },
-    {
-      $Type  : 'UI.DataFieldForAction',
-      Action : 'AdminService.ODataServices_refreshMetadata',
-      Label  : 'Refresh Metadata',
-      RequiresContext : true
-    }
+    { Value: last_updated,  Label: 'Last Updated' }
   ],
   Identification: [
     { Value: service_base_url, Label: 'Base URL' },
@@ -34,7 +28,13 @@ namespace db;
     { Value: active,           Label: 'Active' },
     { Value: created_at,       Label: 'Created At' },
     { Value: last_updated,     Label: 'Last Updated' },
-    { Value: odata_version,    Label: 'OData Version' }
+    { Value: odata_version,    Label: 'OData Version' },
+    {
+      $Type  : 'UI.DataFieldForAction',
+      Action : 'AdminService.ODataServices_refreshMetadata',
+      Label  : 'Refresh Metadata',
+      RequiresContext : true
+    }
   ]
 }
 entity ODataServices {


### PR DESCRIPTION
## Summary
- show `refreshMetadata` action in detail page Identification instead of list
- handle single-service refresh in admin-service

## Testing
- `pip install -r fastapi_backend/requirements.txt pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2383e1d0832b927c3e1b3101d782