### PR TITLE
Move refresh action to detail view

### DIFF
--- a/cap_ui/db/schema.cds
+++ b/cap_ui/db/schema.cds
@@ -20,13 +20,7 @@ namespace db;
     { Value: odata_version,    Label: 'OData Version' },
     { Value: active,        Label: 'Active' },
     { Value: created_at,    Label: 'Created At' },
-    { Value: last_updated,  Label: 'Last Updated' },
-    {
-      $Type  : 'UI.DataFieldForAction',
-      Action : 'AdminService.ODataServices_refreshMetadata',
-      Label  : 'Refresh Metadata',
-      RequiresContext : true
-    }
+    { Value: last_updated,  Label: 'Last Updated' }
   ],
   Identification: [
     { Value: service_base_url, Label: 'Base URL' },
@@ -34,7 +28,14 @@ namespace db;
     { Value: active,           Label: 'Active' },
     { Value: created_at,       Label: 'Created At' },
     { Value: last_updated,     Label: 'Last Updated' },
-    { Value: odata_version,    Label: 'OData Version' }
+    { Value: odata_version,    Label: 'OData Version' },
+    {
+      $Type  : 'UI.DataFieldForAction',
+      Action : 'AdminService.ODataServices_refreshMetadata',
+      Label  : 'Refresh Metadata',
+      Hidden : { $Path: 'IsActiveEntity' },
+      RequiresContext : true
+    }
   ]
 }
 entity ODataServices {

--- a/cap_ui/srv/admin-service.js
+++ b/cap_ui/srv/admin-service.js
@@ -114,45 +114,33 @@ module.exports = srv => {
   });
 
   srv.on('refreshMetadata', async req => {
-    const ids =
-      (Array.isArray(req.data?.IDs) && req.data.IDs) ||
-      (Array.isArray(req.params) && req.params.map(p => p.ID)) ||
-      [];
-    if (!ids.length && req.params?.[0]?.ID) ids.push(req.params[0].ID);
-    if (!ids.length) return req.error(400, 'No service IDs provided');
+    const ID =
+      req.data?.ID ||
+      (Array.isArray(req.data?.IDs) && req.data.IDs[0]) ||
+      (req.params?.[0] && req.params[0].ID);
+    if (!ID) return req.error(400, 'Service ID required');
 
     const tx = srv.tx(req);
-    const results = [];
-
-    for (const ID of ids) {
-      const service = await tx.run(SELECT.one.from(ODataServices).where({ ID }));
-      if (!service) {
-        req.error(`Service not found for ID ${ID}`);
-        results.push({ ID, status: 'failed', message: 'Service not found' });
-        continue;
-      }
-      try {
-        const { json, version, url } = await fetchMetadata(
-          service.service_base_url,
-          service.service_name
-        );
-        req.info(`Fetched metadata from ${url}`);
-        await tx.run(
-          UPDATE(ODataServices, ID).set({
-            metadata_json: json,
-            odata_version: version,
-            last_updated: new Date()
-          })
-        );
-        req.info(`Metadata refreshed for ${service.service_name}`);
-        results.push({ ID, status: 'success' });
-      } catch (e) {
-        req.error(e.message);
-        results.push({ ID, status: 'failed', message: e.message });
-      }
+    const service = await tx.run(SELECT.one.from(ODataServices).where({ ID }));
+    if (!service) return req.error(404, 'Service not found');
+    try {
+      const { json, version, url } = await fetchMetadata(
+        service.service_base_url,
+        service.service_name
+      );
+      req.info(`Fetched metadata from ${url}`);
+      await tx.run(
+        UPDATE(ODataServices, ID).set({
+          metadata_json: json,
+          odata_version: version,
+          last_updated: new Date()
+        })
+      );
+      req.info('Metadata refreshed successfully');
+      return tx.run(SELECT.one.from(ODataServices).where({ ID }));
+    } catch (e) {
+      return req.error(500, e.message);
     }
-
-    return results;
   });
 
   srv.on('toggleActive', async req => {


### PR DESCRIPTION
## Summary
- relocate the Refresh Metadata button to the detail page
- enable the action only when a draft (edit mode) is active
- simplify refresh logic in admin service to handle a single service

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2383e1d0832b927c3e1b3101d782