### PR TITLE
Implement refreshMetadata action

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ metadata.
 
 For a quick test use the public Northwind OData endpoint. Create a new record in
 the CAP admin UI with the base URL `https://services.odata.org` and the service
-name `northwind/northwind.svc`. Then execute the
+name `northwind/northwind.svc`. After saving the record execute the
 `refreshMetadata` action. The metadata JSON will be stored in the database and
 the `odata_version` column will indicate whether the service is v2 or v4.

--- a/cap_ui/db/schema.cds
+++ b/cap_ui/db/schema.cds
@@ -33,7 +33,7 @@ namespace db;
       $Type  : 'UI.DataFieldForAction',
       Action : 'AdminService.ODataServices_refreshMetadata',
       Label  : 'Refresh Metadata',
-      Hidden : { $Path: 'IsActiveEntity' },
+      Hidden : { '=': [ { $Path: 'IsActiveEntity' }, false ] },
       RequiresContext : true
     }
   ]

--- a/cap_ui/srv/admin-service.js
+++ b/cap_ui/srv/admin-service.js
@@ -120,6 +120,10 @@ module.exports = srv => {
       (req.params?.[0] && req.params[0].ID);
     if (!ID) return req.error(400, 'Service ID required');
 
+    if (req.params?.[0]?.IsActiveEntity === false) {
+      return req.error(400, 'Please save the draft before refreshing metadata.');
+    }
+
     const tx = srv.tx(req);
     const service = await tx.run(SELECT.one.from(ODataServices).where({ ID }));
     if (!service) return req.error(404, 'Service not found');
@@ -137,7 +141,7 @@ module.exports = srv => {
         })
       );
       req.info('Metadata refreshed successfully');
-      return tx.run(SELECT.one.from(ODataServices).where({ ID }));
+      return { message: `Metadata refreshed from ${url}` };
     } catch (e) {
       return req.error(500, e.message);
     }


### PR DESCRIPTION
## Summary
- expose a bound `refreshMetadata` action on `ODataServices`
- restrict the action to active records only and return a message
- show action button only for active entities in Fiori UI
- update README instructions

## Testing
- `pip install -r fastapi_backend/requirements.txt pytest`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687d290cf15c832bbfa9d2ad3845bba4