### PR TITLE
Regenerate CAP service with bound action

### DIFF
--- a/cap_ui/gen/srv/package.json
+++ b/cap_ui/gen/srv/package.json
@@ -7,18 +7,22 @@
     "build": "cds build"
   },
   "dependencies": {
-    "@sap/cds": "^8.9.4",
-    "sqlite3": "^5"
+    "@sap/cds": "^7",
+    "sqlite3": "^5",
+    "node-fetch": "^2",
+    "xml2js": "^0.6",
+    "dotenv": "^16"
   },
   "cds": {
     "requires": {
-      "db": {
-        "kind": "sqlite",
-        "credentials": {
-          "database": "../shared.sqlite"
-        }
+    "db":{
+      "kind": "sqlite",
+      "credentials": {
+        "database": "../shared.sqlite"
       }
     }
-
+  }},
+  "devDependencies": {
+    "@sap/cds-dk": "^8.9.7"
   }
 }

--- a/cap_ui/gen/srv/srv/admin-service.js
+++ b/cap_ui/gen/srv/srv/admin-service.js
@@ -1,13 +1,174 @@
+const cds = require('@sap/cds');
+const { SELECT, UPDATE } = cds;
+const fetch = require('node-fetch');
+const xml2js = require('xml2js');
+const { URL } = require('url');
+require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') });
+
+const AUTH_HEADER = (() => {
+  const user = process.env.SAP_USER;
+  const pass = process.env.SAP_PASS;
+  if (user && pass) {
+    const token = Buffer.from(`${user}:${pass}`).toString('base64');
+    return { Authorization: `Basic ${token}` };
+  }
+  return {};
+})();
+function buildMetadataUrl(baseUrl, serviceName) {
+  const base = baseUrl.endsWith('/') ? baseUrl : baseUrl + '/';
+  const path = `${serviceName.replace(/^\//, '')}/$metadata`;
+  return new URL(path, base).toString();
+}
+
+function extractEntities(parsed) {
+  const edmx = parsed['edmx:Edmx'] || parsed['edmx:edmx'] || {};
+  const dataservices =
+    (edmx['edmx:DataServices'] && edmx['edmx:DataServices'][0]) ||
+    (edmx['edmx:dataservices'] && edmx['edmx:dataservices'][0]) || {};
+  const schemas = dataservices.Schema || [];
+  const entities = [];
+  for (const schema of schemas) {
+    const container = (schema.EntityContainer && schema.EntityContainer[0]) || {};
+    const sets = container.EntitySet || [];
+    for (const set of sets) {
+      const name = set.$ && set.$.Name;
+      if (name) entities.push({ name });
+    }
+    if (!sets.length && schema.EntityType) {
+      for (const type of schema.EntityType) {
+        const name = type.$ && type.$.Name;
+        if (name) entities.push({ name });
+      }
+    }
+  }
+  return entities;
+}
+
+async function fetchMetadata(baseUrl, serviceName) {
+  const url = buildMetadataUrl(baseUrl, serviceName);
+  const res = await fetch(url, { headers: AUTH_HEADER });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch metadata from ${url}: ${res.status} ${res.statusText}`);
+  }
+  const xml = await res.text();
+  if (!xml.includes('<edmx:')) {
+    throw new Error(`Invalid metadata response from ${url}`);
+  }
+  const obj = await xml2js.parseStringPromise(xml);
+  const entities = extractEntities(obj);
+  const json = JSON.stringify({ entities });
+  const version = await parseVersion(xml);
+  return { json, version, url };
+}
+
+async function parseVersion(xml) {
+  try {
+    const data = await xml2js.parseStringPromise(xml);
+    const edmx = data['edmx:Edmx'] || data['edmx:edmx'] || {};
+    const ver = edmx.$ ? edmx.$.Version : null;
+    if (ver) {
+      return ver.startsWith('4') ? 'v4' : `v${ver.split('.')[0]}`;
+    }
+  } catch (e) {
+    /* ignore */
+  }
+  return null;
+}
+
 module.exports = srv => {
   const { ODataServices } = srv.entities;
 
-  srv.before(['CREATE', 'UPDATE'], ODataServices, req => {
-    if (req.data.metadata_json) {
-      // metadata provided directly
+
+  srv.before(['CREATE', 'UPDATE', 'NEW', 'PATCH'], ODataServices, async req => {
+    try {
+      if (
+        !req.data.metadata_json &&
+        req.data.service_base_url &&
+        req.data.service_name
+      ) {
+        const { json, version, url } = await fetchMetadata(
+          req.data.service_base_url,
+          req.data.service_name
+        );
+        req.info(`Fetched metadata from ${url}`);
+        req.data.metadata_json = json;
+        req.data.odata_version = version;
+        req.info('Metadata fetched successfully');
+      }
+      if (
+        req.data.metadata_json &&
+        !(req.data.service_base_url && req.data.service_name)
+      ) {
+        // metadata_json provided directly
+        const parsed = await parseVersion(req.data.metadata_json);
+        if (parsed) req.data.odata_version = parsed;
+        req.info('Metadata updated from request');
+      }
+    } catch (e) {
+      req.error(500, e.message);
     }
     req.data.last_updated = new Date();
-    if (req.event === 'CREATE' && !req.data.created_at) {
+    if (req.event === 'CREATE' || req.event === 'NEW') {
       req.data.created_at = new Date();
+    }
+  });
+
+  srv.on('refreshMetadata', async req => {
+    const ID =
+      req.data?.ID ||
+      (Array.isArray(req.data?.IDs) && req.data.IDs[0]) ||
+      (req.params?.[0] && req.params[0].ID);
+    if (!ID) return req.error(400, 'Service ID required');
+
+    if (req.data?.IsActiveEntity === false) {
+      return req.error(400, 'Please save the draft before refreshing metadata.');
+    }
+
+    const tx = srv.tx(req);
+    const service = await tx.run(SELECT.one.from(ODataServices).where({ ID }));
+    if (!service) return req.error(404, 'Service not found');
+    try {
+      const { json, version, url } = await fetchMetadata(
+        service.service_base_url,
+        service.service_name
+      );
+      req.info(`Fetched metadata from ${url}`);
+      await tx.run(
+        UPDATE(ODataServices, ID).set({
+          metadata_json: json,
+          odata_version: version,
+          last_updated: new Date()
+        })
+      );
+      req.info('Metadata refreshed successfully');
+      return { message: `Metadata refreshed from ${url}` };
+    } catch (e) {
+      return req.error(500, e.message);
+    }
+  });
+
+  srv.on('toggleActive', async req => {
+    const { ID } = req.params[0];
+    const tx = srv.tx(req);
+    const service = await tx.run(SELECT.one.from(ODataServices).where({ ID }));
+    if (!service) return req.error(404, 'Service not found');
+    try {
+      const { json, version, url } = await fetchMetadata(
+        service.service_base_url,
+        service.service_name
+      );
+      req.info(`Fetched metadata from ${url}`);
+      await tx.run(
+        UPDATE(ODataServices, ID).set({
+          metadata_json: json,
+          odata_version: version,
+          last_updated: new Date()
+        })
+      );
+      req.info('Metadata refreshed successfully');
+      return tx.run(SELECT.one.from(ODataServices).where({ ID }));
+    } catch (e) {
+      return req.error(500, e.message);
     }
   });
 };

--- a/cap_ui/gen/srv/srv/csn.json
+++ b/cap_ui/gen/srv/srv/csn.json
@@ -9,14 +9,33 @@
       "@UI.HeaderInfo.TypeNamePlural": "OData Services",
       "@UI.HeaderInfo.TypeName": "OData Service",
       "@UI.HeaderInfo.Title.Value": {
-        "=": "service_url"
+        "=": "service_name"
       },
+      "@UI.Facets": [
+        {
+          "$Type": "UI.ReferenceFacet",
+          "Label": "Service Name",
+          "Target": "@UI.Identification"
+        }
+      ],
       "@UI.LineItem": [
         {
           "Value": {
-            "=": "service_url"
+            "=": "service_base_url"
           },
-          "Label": "Service URL"
+          "Label": "Base URL"
+        },
+        {
+          "Value": {
+            "=": "service_name"
+          },
+          "Label": "Service Name"
+        },
+        {
+          "Value": {
+            "=": "odata_version"
+          },
+          "Label": "OData Version"
         },
         {
           "Value": {
@@ -37,17 +56,78 @@
           "Label": "Last Updated"
         }
       ],
+      "@UI.Identification": [
+        {
+          "Value": {
+            "=": "service_base_url"
+          },
+          "Label": "Base URL"
+        },
+        {
+          "Value": {
+            "=": "service_name"
+          },
+          "Label": "Service Name"
+        },
+        {
+          "Value": {
+            "=": "active"
+          },
+          "Label": "Active"
+        },
+        {
+          "Value": {
+            "=": "created_at"
+          },
+          "Label": "Created At"
+        },
+        {
+          "Value": {
+            "=": "last_updated"
+          },
+          "Label": "Last Updated"
+        },
+        {
+          "Value": {
+            "=": "odata_version"
+          },
+          "Label": "OData Version"
+        },
+        {
+          "$Type": "UI.DataFieldForAction",
+          "Action": "AdminService.ODataServices_refreshMetadata",
+          "Label": "Refresh Metadata",
+          "Hidden": {
+            "xpr": [
+              "not",
+              "IsActiveEntity"
+            ]
+          },
+          "RequiresContext": true
+        }
+      ],
       "elements": {
         "ID": {
           "@UI.Hidden": true,
           "key": true,
           "type": "cds.UUID"
         },
-        "service_url": {
+        "service_base_url": {
+          "@UI.Identification": true,
+          "type": "cds.String"
+        },
+        "service_name": {
+          "@UI.Identification": true,
           "type": "cds.String"
         },
         "metadata_json": {
+          "@UI.Hidden": true,
           "type": "cds.LargeString"
+        },
+        "odata_version": {
+          "@UI.Identification": true,
+          "@UI.LineItem": true,
+          "type": "cds.String"
         },
         "active": {
           "type": "cds.Boolean",
@@ -56,9 +136,20 @@
           }
         },
         "created_at": {
+          "@Core.Computed": true,
+          "@cds.on.insert": {
+            "=": "$now"
+          },
           "type": "cds.Timestamp"
         },
         "last_updated": {
+          "@Core.Computed": true,
+          "@cds.on.insert": {
+            "=": "$now"
+          },
+          "@cds.on.update": {
+            "=": "$now"
+          },
           "type": "cds.Timestamp"
         }
       }
@@ -76,14 +167,33 @@
       "@UI.HeaderInfo.TypeNamePlural": "OData Services",
       "@UI.HeaderInfo.TypeName": "OData Service",
       "@UI.HeaderInfo.Title.Value": {
-        "=": "service_url"
+        "=": "service_name"
       },
+      "@UI.Facets": [
+        {
+          "$Type": "UI.ReferenceFacet",
+          "Label": "Service Name",
+          "Target": "@UI.Identification"
+        }
+      ],
       "@UI.LineItem": [
         {
           "Value": {
-            "=": "service_url"
+            "=": "service_base_url"
           },
-          "Label": "Service URL"
+          "Label": "Base URL"
+        },
+        {
+          "Value": {
+            "=": "service_name"
+          },
+          "Label": "Service Name"
+        },
+        {
+          "Value": {
+            "=": "odata_version"
+          },
+          "Label": "OData Version"
         },
         {
           "Value": {
@@ -104,6 +214,56 @@
           "Label": "Last Updated"
         }
       ],
+      "@UI.Identification": [
+        {
+          "Value": {
+            "=": "service_base_url"
+          },
+          "Label": "Base URL"
+        },
+        {
+          "Value": {
+            "=": "service_name"
+          },
+          "Label": "Service Name"
+        },
+        {
+          "Value": {
+            "=": "active"
+          },
+          "Label": "Active"
+        },
+        {
+          "Value": {
+            "=": "created_at"
+          },
+          "Label": "Created At"
+        },
+        {
+          "Value": {
+            "=": "last_updated"
+          },
+          "Label": "Last Updated"
+        },
+        {
+          "Value": {
+            "=": "odata_version"
+          },
+          "Label": "OData Version"
+        },
+        {
+          "$Type": "UI.DataFieldForAction",
+          "Action": "AdminService.ODataServices_refreshMetadata",
+          "Label": "Refresh Metadata",
+          "Hidden": {
+            "xpr": [
+              "not",
+              "IsActiveEntity"
+            ]
+          },
+          "RequiresContext": true
+        }
+      ],
       "projection": {
         "from": {
           "ref": [
@@ -117,11 +277,22 @@
           "key": true,
           "type": "cds.UUID"
         },
-        "service_url": {
+        "service_base_url": {
+          "@UI.Identification": true,
+          "type": "cds.String"
+        },
+        "service_name": {
+          "@UI.Identification": true,
           "type": "cds.String"
         },
         "metadata_json": {
+          "@UI.Hidden": true,
           "type": "cds.LargeString"
+        },
+        "odata_version": {
+          "@UI.Identification": true,
+          "@UI.LineItem": true,
+          "type": "cds.String"
         },
         "active": {
           "type": "cds.Boolean",
@@ -130,16 +301,32 @@
           }
         },
         "created_at": {
+          "@Core.Computed": true,
+          "@cds.on.insert": {
+            "=": "$now"
+          },
           "type": "cds.Timestamp"
         },
         "last_updated": {
+          "@Core.Computed": true,
+          "@cds.on.insert": {
+            "=": "$now"
+          },
+          "@cds.on.update": {
+            "=": "$now"
+          },
           "type": "cds.Timestamp"
+        }
+      },
+      "actions": {
+        "refreshMetadata": {
+          "kind": "action"
         }
       }
     }
   },
   "meta": {
-    "creator": "CDS Compiler v5.9.8",
+    "creator": "CDS Compiler v4.9.10",
     "flavor": "inferred"
   },
   "$version": "2.0"

--- a/cap_ui/gen/srv/srv/odata/v4/AdminService.xml
+++ b/cap_ui/gen/srv/srv/odata/v4/AdminService.xml
@@ -14,14 +14,6 @@
   </edmx:Reference>
   <edmx:DataServices>
     <Schema Namespace="AdminService" xmlns="http://docs.oasis-open.org/odata/ns/edm">
-      <Annotation Term="Core.Links">
-        <Collection>
-          <Record>
-            <PropertyValue Property="rel" String="author"/>
-            <PropertyValue Property="href" String="https://cap.cloud.sap"/>
-          </Record>
-        </Collection>
-      </Annotation>
       <EntityContainer Name="EntityContainer">
         <EntitySet Name="ODataServices" EntityType="AdminService.ODataServices">
           <NavigationPropertyBinding Path="SiblingEntity" Target="ODataServices"/>
@@ -33,8 +25,10 @@
           <PropertyRef Name="IsActiveEntity"/>
         </Key>
         <Property Name="ID" Type="Edm.Guid" Nullable="false"/>
-        <Property Name="service_url" Type="Edm.String"/>
+        <Property Name="service_base_url" Type="Edm.String"/>
+        <Property Name="service_name" Type="Edm.String"/>
         <Property Name="metadata_json" Type="Edm.String"/>
+        <Property Name="odata_version" Type="Edm.String"/>
         <Property Name="active" Type="Edm.Boolean" DefaultValue="true"/>
         <Property Name="created_at" Type="Edm.DateTimeOffset" Precision="7"/>
         <Property Name="last_updated" Type="Edm.DateTimeOffset" Precision="7"/>
@@ -57,6 +51,9 @@
         <Property Name="InProcessByUser" Type="Edm.String" MaxLength="256"/>
         <Property Name="DraftIsProcessedByMe" Type="Edm.Boolean"/>
       </EntityType>
+      <Action Name="refreshMetadata" IsBound="true">
+        <Parameter Name="in" Type="AdminService.ODataServices"/>
+      </Action>
       <Action Name="draftPrepare" IsBound="true" EntitySetPath="in">
         <Parameter Name="in" Type="AdminService.ODataServices"/>
         <Parameter Name="SideEffectsQualifier" Type="Edm.String"/>
@@ -78,16 +75,32 @@
             <PropertyValue Property="TypeName" String="OData Service"/>
             <PropertyValue Property="Title">
               <Record Type="UI.DataField">
-                <PropertyValue Property="Value" Path="service_url"/>
+                <PropertyValue Property="Value" Path="service_name"/>
               </Record>
             </PropertyValue>
           </Record>
         </Annotation>
+        <Annotation Term="UI.Facets">
+          <Collection>
+            <Record Type="UI.ReferenceFacet">
+              <PropertyValue Property="Label" String="Service Name"/>
+              <PropertyValue Property="Target" AnnotationPath="@UI.Identification"/>
+            </Record>
+          </Collection>
+        </Annotation>
         <Annotation Term="UI.LineItem">
           <Collection>
             <Record Type="UI.DataField">
-              <PropertyValue Property="Value" Path="service_url"/>
-              <PropertyValue Property="Label" String="Service URL"/>
+              <PropertyValue Property="Value" Path="service_base_url"/>
+              <PropertyValue Property="Label" String="Base URL"/>
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="service_name"/>
+              <PropertyValue Property="Label" String="Service Name"/>
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="odata_version"/>
+              <PropertyValue Property="Label" String="OData Version"/>
             </Record>
             <Record Type="UI.DataField">
               <PropertyValue Property="Value" Path="active"/>
@@ -100,6 +113,49 @@
             <Record Type="UI.DataField">
               <PropertyValue Property="Value" Path="last_updated"/>
               <PropertyValue Property="Label" String="Last Updated"/>
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.Identification">
+          <Collection>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="service_base_url"/>
+              <PropertyValue Property="Label" String="Base URL"/>
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="service_name"/>
+              <PropertyValue Property="Label" String="Service Name"/>
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="active"/>
+              <PropertyValue Property="Label" String="Active"/>
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="created_at"/>
+              <PropertyValue Property="Label" String="Created At"/>
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="last_updated"/>
+              <PropertyValue Property="Label" String="Last Updated"/>
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="odata_version"/>
+              <PropertyValue Property="Label" String="OData Version"/>
+            </Record>
+            <Record Type="UI.DataFieldForAction">
+              <PropertyValue Property="Action" String="AdminService.ODataServices_refreshMetadata"/>
+              <PropertyValue Property="Label" String="Refresh Metadata"/>
+              <PropertyValue Property="Hidden">
+                <Record>
+                  <PropertyValue Property="xpr">
+                    <Collection>
+                      <String>not</String>
+                      <String>IsActiveEntity</String>
+                    </Collection>
+                  </PropertyValue>
+                </Record>
+              </PropertyValue>
+              <PropertyValue Property="RequiresContext" Bool="true"/>
             </Record>
           </Collection>
         </Annotation>
@@ -131,6 +187,15 @@
       <Annotations Target="AdminService.ODataServices/ID">
         <Annotation Term="UI.Hidden" Bool="true"/>
         <Annotation Term="Core.ComputedDefaultValue" Bool="true"/>
+      </Annotations>
+      <Annotations Target="AdminService.ODataServices/metadata_json">
+        <Annotation Term="UI.Hidden" Bool="true"/>
+      </Annotations>
+      <Annotations Target="AdminService.ODataServices/created_at">
+        <Annotation Term="Core.Computed" Bool="true"/>
+      </Annotations>
+      <Annotations Target="AdminService.ODataServices/last_updated">
+        <Annotation Term="Core.Computed" Bool="true"/>
       </Annotations>
       <Annotations Target="AdminService.ODataServices/IsActiveEntity">
         <Annotation Term="UI.Hidden" Bool="true"/>


### PR DESCRIPTION
## Summary
- regenerate CAP service outputs so bound `refreshMetadata` action is published

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3095deb0832ba5662668c9f31c8a