### PR TITLE
Remove manual metadata refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ metadata.
 
 For a quick test use the public Northwind OData endpoint. Create a new record in
 the CAP admin UI with the base URL `https://services.odata.org` and the service
-name `northwind/northwind.svc`. After saving the record execute the
-`refreshMetadata` action. The metadata JSON will be stored in the database and
-the `odata_version` column will indicate whether the service is v2 or v4.
+name `northwind/northwind.svc`. After saving the record the service metadata is
+automatically fetched and stored in the database. The `odata_version` column
+will indicate whether the service is v2 or v4.

--- a/cap_ui/db/schema.cds
+++ b/cap_ui/db/schema.cds
@@ -28,14 +28,7 @@ namespace db;
     { Value: active,           Label: 'Active' },
     { Value: created_at,       Label: 'Created At' },
     { Value: last_updated,     Label: 'Last Updated' },
-    { Value: odata_version,    Label: 'OData Version' },
-    {
-      $Type  : 'UI.DataFieldForAction',
-      Action : 'AdminService.ODataServices_refreshMetadata',
-      Label  : 'Refresh Metadata',
-    Hidden : { xpr: ['not', 'IsActiveEntity'] },
-      RequiresContext : true
-    }
+    { Value: odata_version,    Label: 'OData Version' }
   ]
 }
 entity ODataServices {

--- a/cap_ui/gen/srv/srv/admin-service.js
+++ b/cap_ui/gen/srv/srv/admin-service.js
@@ -113,62 +113,6 @@ module.exports = srv => {
     }
   });
 
-  srv.on('refreshMetadata', async req => {
-    const ID =
-      req.data?.ID ||
-      (Array.isArray(req.data?.IDs) && req.data.IDs[0]) ||
-      (req.params?.[0] && req.params[0].ID);
-    if (!ID) return req.error(400, 'Service ID required');
-
-    if (req.data?.IsActiveEntity === false) {
-      return req.error(400, 'Please save the draft before refreshing metadata.');
-    }
-
-    const tx = srv.tx(req);
-    const service = await tx.run(SELECT.one.from(ODataServices).where({ ID }));
-    if (!service) return req.error(404, 'Service not found');
-    try {
-      const { json, version, url } = await fetchMetadata(
-        service.service_base_url,
-        service.service_name
-      );
-      req.info(`Fetched metadata from ${url}`);
-      await tx.run(
-        UPDATE(ODataServices, ID).set({
-          metadata_json: json,
-          odata_version: version,
-          last_updated: new Date()
-        })
-      );
-      req.info('Metadata refreshed successfully');
-      return { message: `Metadata refreshed from ${url}` };
-    } catch (e) {
-      return req.error(500, e.message);
-    }
-  });
-
-  srv.on('toggleActive', async req => {
-    const { ID } = req.params[0];
-    const tx = srv.tx(req);
-    const service = await tx.run(SELECT.one.from(ODataServices).where({ ID }));
-    if (!service) return req.error(404, 'Service not found');
-    try {
-      const { json, version, url } = await fetchMetadata(
-        service.service_base_url,
-        service.service_name
-      );
-      req.info(`Fetched metadata from ${url}`);
-      await tx.run(
-        UPDATE(ODataServices, ID).set({
-          metadata_json: json,
-          odata_version: version,
-          last_updated: new Date()
-        })
-      );
-      req.info('Metadata refreshed successfully');
-      return tx.run(SELECT.one.from(ODataServices).where({ ID }));
-    } catch (e) {
-      return req.error(500, e.message);
-    }
-  });
+  // Manual refresh and toggle actions have been removed. Metadata is fetched
+  // automatically during create or update operations.
 };

--- a/cap_ui/gen/srv/srv/csn.json
+++ b/cap_ui/gen/srv/srv/csn.json
@@ -93,18 +93,6 @@
           },
           "Label": "OData Version"
         },
-        {
-          "$Type": "UI.DataFieldForAction",
-          "Action": "AdminService.ODataServices_refreshMetadata",
-          "Label": "Refresh Metadata",
-          "Hidden": {
-            "xpr": [
-              "not",
-              "IsActiveEntity"
-            ]
-          },
-          "RequiresContext": true
-        }
       ],
       "elements": {
         "ID": {
@@ -251,18 +239,6 @@
           },
           "Label": "OData Version"
         },
-        {
-          "$Type": "UI.DataFieldForAction",
-          "Action": "AdminService.ODataServices_refreshMetadata",
-          "Label": "Refresh Metadata",
-          "Hidden": {
-            "xpr": [
-              "not",
-              "IsActiveEntity"
-            ]
-          },
-          "RequiresContext": true
-        }
       ],
       "projection": {
         "from": {
@@ -318,11 +294,7 @@
           "type": "cds.Timestamp"
         }
       },
-      "actions": {
-        "refreshMetadata": {
-          "kind": "action"
-        }
-      }
+      "actions": {}
     }
   },
   "meta": {

--- a/cap_ui/gen/srv/srv/odata/v4/AdminService.xml
+++ b/cap_ui/gen/srv/srv/odata/v4/AdminService.xml
@@ -51,9 +51,6 @@
         <Property Name="InProcessByUser" Type="Edm.String" MaxLength="256"/>
         <Property Name="DraftIsProcessedByMe" Type="Edm.Boolean"/>
       </EntityType>
-      <Action Name="refreshMetadata" IsBound="true">
-        <Parameter Name="in" Type="AdminService.ODataServices"/>
-      </Action>
       <Action Name="draftPrepare" IsBound="true" EntitySetPath="in">
         <Parameter Name="in" Type="AdminService.ODataServices"/>
         <Parameter Name="SideEffectsQualifier" Type="Edm.String"/>
@@ -141,21 +138,6 @@
             <Record Type="UI.DataField">
               <PropertyValue Property="Value" Path="odata_version"/>
               <PropertyValue Property="Label" String="OData Version"/>
-            </Record>
-            <Record Type="UI.DataFieldForAction">
-              <PropertyValue Property="Action" String="AdminService.ODataServices_refreshMetadata"/>
-              <PropertyValue Property="Label" String="Refresh Metadata"/>
-              <PropertyValue Property="Hidden">
-                <Record>
-                  <PropertyValue Property="xpr">
-                    <Collection>
-                      <String>not</String>
-                      <String>IsActiveEntity</String>
-                    </Collection>
-                  </PropertyValue>
-                </Record>
-              </PropertyValue>
-              <PropertyValue Property="RequiresContext" Bool="true"/>
             </Record>
           </Collection>
         </Annotation>

--- a/cap_ui/srv/service.cds
+++ b/cap_ui/srv/service.cds
@@ -2,7 +2,5 @@ using { db as my } from '../db/schema';
 
 service AdminService {
   @odata.draft.enabled
-  entity ODataServices as projection on my.ODataServices actions {
-    action refreshMetadata();
-  };
+  entity ODataServices as projection on my.ODataServices;
 }


### PR DESCRIPTION
## Summary
- automate metadata fetch during creation
- remove `refreshMetadata` action from CDS service
- drop UI action annotation
- delete obsolete refresh/toggle handlers
- update generated metadata files

## Testing
- `pip install -r fastapi_backend/requirements.txt pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d32cae2e4832bbe793fccc267b67d