### PR TITLE
Handle metadata fetch on draft activation

### DIFF
--- a/cap_ui/gen/srv/srv/admin-service.js
+++ b/cap_ui/gen/srv/srv/admin-service.js
@@ -113,6 +113,21 @@ module.exports = srv => {
     }
   });
 
+  srv.on('draftActivate', ODataServices, async (req, next) => {
+    const result = await next();
+    await applyMetadata(req);
+    await cds.run(
+      UPDATE(ODataServices)
+        .set({
+          metadata_json: req.data.metadata_json,
+          odata_version: req.data.odata_version,
+          last_updated: req.data.last_updated,
+        })
+        .where({ ID: result.ID })
+    );
+    return result;
+  });
+
   // Manual refresh and toggle actions have been removed. Metadata is fetched
   // automatically during create or update operations.
 };


### PR DESCRIPTION
## Summary
- hook into the `draftActivate` event
- regenerate AdminService code
- update metadata on draft activation

## Testing
- `pip install -r fastapi_backend/requirements.txt pytest`
- `pip install httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3c6ad894832b8df96722d715269b