### PR TITLE
Handle metadata update in PATCH after hooks

### DIFF
--- a/cap_ui/gen/srv/srv/admin-service.js
+++ b/cap_ui/gen/srv/srv/admin-service.js
@@ -79,7 +79,7 @@ module.exports = srv => {
   const { ODataServices } = srv.entities;
 
 
-  srv.before(['CREATE', 'UPDATE', 'NEW', 'PATCH'], ODataServices, async req => {
+  srv.before(['CREATE', 'UPDATE', 'NEW'], ODataServices, async req => {
     try {
       if (
         !req.data.metadata_json &&
@@ -113,8 +113,8 @@ module.exports = srv => {
     }
   });
 
-  srv.on('draftActivate', ODataServices, async (req, next) => {
-    const result = await next();
+  srv.after('PATCH', ODataServices, async (data, req) => {
+    console.log('✅ PATCH after fired');
     await applyMetadata(req);
     await cds.run(
       UPDATE(ODataServices)
@@ -123,9 +123,8 @@ module.exports = srv => {
           odata_version: req.data.odata_version,
           last_updated: req.data.last_updated,
         })
-        .where({ ID: result.ID })
+        .where({ ID: data.ID })
     );
-    return result;
   });
 
   // Manual refresh and toggle actions have been removed. Metadata is fetched

--- a/cap_ui/srv/admin-service.js
+++ b/cap_ui/srv/admin-service.js
@@ -114,10 +114,9 @@ module.exports = srv => {
   }
 
   srv.before('CREATE', ODataServices, applyMetadata);
-  srv.before('PATCH', ODataServices, applyMetadata);
 
-  srv.on('draftActivate', ODataServices, async (req, next) => {
-    const result = await next();
+  srv.after('PATCH', ODataServices, async (data, req) => {
+    console.log('✅ PATCH after fired');
     await applyMetadata(req);
     await cds.run(
       UPDATE(ODataServices)
@@ -126,9 +125,8 @@ module.exports = srv => {
           odata_version: req.data.odata_version,
           last_updated: req.data.last_updated,
         })
-        .where({ ID: result.ID })
+        .where({ ID: data.ID })
     );
-    return result;
   });
 
   // Manual refresh and toggle actions have been removed. Metadata is now


### PR DESCRIPTION
## Summary
- remove outdated draftActivate handler
- trigger metadata update after successful PATCH instead
- remove before PATCH hook from generated service
- verify hook runs with console output

## Testing
- `pip install -r fastapi_backend/requirements.txt pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3fe88c4c832ba8940c17db1c0053