### PR TITLE
Add detailed OData metadata parser

### DIFF
--- a/cap_ui/srv/admin-service.js
+++ b/cap_ui/srv/admin-service.js
@@ -3,6 +3,8 @@ const { SELECT, UPDATE } = cds.ql;
 const fetch = require('node-fetch');
 const xml2js = require('xml2js');
 const { URL } = require('url');
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
 require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') });
 
 const AUTH_HEADER = (() => {
@@ -20,29 +22,198 @@ function buildMetadataUrl(baseUrl, serviceName) {
   return new URL(path, base).toString();
 }
 
-function extractEntities(parsed) {
+function parseNavigationProperties(navs = []) {
+  const result = [];
+  for (const nav of navs) {
+    const n = nav.$ || {};
+    result.push({
+      name: n.Name,
+      relationship: n.Relationship,
+      fromRole: n.FromRole,
+      toRole: n.ToRole,
+      multiplicity: n.Multiplicity,
+      type: n.Type,
+    });
+  }
+  return result;
+}
+
+function parseEntityTypes(schema) {
+  const types = schema.EntityType || [];
+  const result = [];
+  for (const et of types) {
+    const t = et.$ || {};
+    const entity = { name: t.Name, keys: [], properties: [], navigationProperties: [] };
+    if (et.Key && et.Key[0] && et.Key[0].PropertyRef) {
+      for (const ref of et.Key[0].PropertyRef) {
+        if (ref.$ && ref.$.Name) entity.keys.push(ref.$.Name);
+      }
+    }
+    if (et.Property) {
+      for (const p of et.Property) {
+        const a = p.$ || {};
+        entity.properties.push({
+          name: a.Name,
+          type: a.Type,
+          nullable: a.Nullable !== 'false',
+          length: a.MaxLength,
+          annotations: (p.Annotation || []).map((ann) => (ann.$ && ann.$.Term) || undefined).filter(Boolean),
+        });
+      }
+    }
+    if (et.NavigationProperty) {
+      entity.navigationProperties = parseNavigationProperties(et.NavigationProperty);
+    }
+    result.push(entity);
+  }
+  return result;
+}
+
+function parseEntitySets(container = {}) {
+  const sets = container.EntitySet || [];
+  const result = [];
+  for (const es of sets) {
+    const a = es.$ || {};
+    result.push({ name: a.Name, entityType: a.EntityType, url: a.Name });
+  }
+  return result;
+}
+
+function parseAssociations(schema) {
+  const associations = schema.Association || [];
+  const result = [];
+  for (const as of associations) {
+    const a = as.$ || {};
+    const assoc = { name: a.Name, ends: [], referentialConstraints: [] };
+    if (as.End) {
+      for (const end of as.End) {
+        const e = end.$ || {};
+        assoc.ends.push({ role: e.Role, type: e.Type, multiplicity: e.Multiplicity });
+      }
+    }
+    if (as.ReferentialConstraint && as.ReferentialConstraint[0]) {
+      const rc = as.ReferentialConstraint[0];
+      const principal = rc.Principal && rc.Principal[0];
+      const dependent = rc.Dependent && rc.Dependent[0];
+      assoc.referentialConstraints.push({
+        principalRole: principal && principal.$ && principal.$.Role,
+        dependentRole: dependent && dependent.$ && dependent.$.Role,
+      });
+    }
+    result.push(assoc);
+  }
+  return result;
+}
+
+function parseComplexTypes(schema) {
+  const types = schema.ComplexType || [];
+  const result = [];
+  for (const ct of types) {
+    const c = ct.$ || {};
+    const fields = [];
+    if (ct.Property) {
+      for (const p of ct.Property) {
+        const a = p.$ || {};
+        fields.push({ name: a.Name, type: a.Type, nullable: a.Nullable !== 'false' });
+      }
+    }
+    result.push({ name: c.Name, fields });
+  }
+  return result;
+}
+
+function parseFunctions(schema) {
+  const funcs = schema.Function || [];
+  const result = [];
+  for (const fn of funcs) {
+    const f = fn.$ || {};
+    const parameters = [];
+    if (fn.Parameter) {
+      for (const p of fn.Parameter) {
+        const a = p.$ || {};
+        parameters.push({ name: a.Name, type: a.Type });
+      }
+    }
+    result.push({
+      name: f.Name,
+      parameters,
+      returnType: fn.ReturnType && fn.ReturnType[0] && fn.ReturnType[0].$ && fn.ReturnType[0].$.Type,
+      isBound: f.IsBound === 'true',
+      bindingParameter: parameters.length ? parameters[0].name : undefined,
+    });
+  }
+  return result;
+}
+
+function parseActions(schema) {
+  const acts = schema.Action || [];
+  const result = [];
+  for (const ac of acts) {
+    const a = ac.$ || {};
+    const parameters = [];
+    if (ac.Parameter) {
+      for (const p of ac.Parameter) {
+        const pa = p.$ || {};
+        parameters.push({ name: pa.Name, type: pa.Type });
+      }
+    }
+    result.push({
+      name: a.Name,
+      parameters,
+      returnType: ac.ReturnType && ac.ReturnType[0] && ac.ReturnType[0].$ && ac.ReturnType[0].$.Type,
+      isBound: a.IsBound === 'true',
+      bindingParameter: parameters.length ? parameters[0].name : undefined,
+    });
+  }
+  return result;
+}
+
+async function parseMetadata(xml) {
+  const parsed = await xml2js.parseStringPromise(xml);
   const edmx = parsed['edmx:Edmx'] || parsed['edmx:edmx'] || {};
   const dataservices =
     (edmx['edmx:DataServices'] && edmx['edmx:DataServices'][0]) ||
     (edmx['edmx:dataservices'] && edmx['edmx:dataservices'][0]) || {};
   const schemas = dataservices.Schema || [];
-  const entities = [];
+  const result = {
+    entities: [],
+    entitySets: [],
+    associations: [],
+    complexTypes: [],
+    functions: [],
+    actions: [],
+  };
   for (const schema of schemas) {
+    result.entities.push(...parseEntityTypes(schema));
     const container = (schema.EntityContainer && schema.EntityContainer[0]) || {};
-    const sets = container.EntitySet || [];
-    for (const set of sets) {
-      const name = set.$ && set.$.Name;
-      if (name) entities.push({ name });
-    }
-    if (!sets.length && schema.EntityType) {
-      for (const type of schema.EntityType) {
-        const name = type.$ && type.$.Name;
-        if (name) entities.push({ name });
-      }
-    }
+    result.entitySets.push(...parseEntitySets(container));
+    result.associations.push(...parseAssociations(schema));
+    result.complexTypes.push(...parseComplexTypes(schema));
+    result.functions.push(...parseFunctions(schema));
+    result.actions.push(...parseActions(schema));
   }
-  return entities;
+  return result;
 }
+
+function detectVersion(xml) {
+  if (xml.includes('http://docs.oasis-open.org/odata/ns/edmx')) return '4.0';
+  if (xml.includes('http://schemas.microsoft.com/ado/2007/06/edmx')) return '2.0';
+  return null;
+}
+
+function saveMetadataToDb(version, json) {
+  const dbPath = path.join(__dirname, '..', 'shared.sqlite');
+  const db = new sqlite3.Database(dbPath);
+  db.serialize(() => {
+    db.run('CREATE TABLE IF NOT EXISTS db_odataservice (version TEXT, metadata_json TEXT)');
+    const stmt = db.prepare('INSERT INTO db_odataservice (version, metadata_json) VALUES (?, ?)');
+    stmt.run(version, json, () => {
+      stmt.finalize();
+      db.close();
+    });
+  });
+}
+
 
 async function fetchMetadata(baseUrl, serviceName) {
   const url = buildMetadataUrl(baseUrl, serviceName);
@@ -55,10 +226,11 @@ async function fetchMetadata(baseUrl, serviceName) {
   if (!xml.includes('<edmx:')) {
     throw new Error(`Invalid metadata response from ${url}`);
   }
-  const obj = await xml2js.parseStringPromise(xml);
-  const entities = extractEntities(obj);
-  const json = JSON.stringify({ entities });
-  const version = await parseVersion(xml);
+  const metadata = await parseMetadata(xml);
+  const version = detectVersion(xml) || (await parseVersion(xml));
+  metadata.version = version;
+  const json = JSON.stringify(metadata);
+  saveMetadataToDb(version, json);
   return { json, version, url };
 }
 


### PR DESCRIPTION
## Summary
- store OData metadata details in `db_odataservice` SQLite table
- detect OData version and parse entity types, complex types and operations
- persist JSON schema and version when metadata is fetched

## Testing
- `pip install -r fastapi_backend/requirements.txt pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d54345e98832bbef5b1bb62dc1e4b