### PR TITLE
Use absolute DB path in FastAPI backend

### DIFF
--- a/fastapi_backend/.env
+++ b/fastapi_backend/.env
@@ -1,2 +1,3 @@
 ODATA_USER=
 ODATA_PASSWORD=
+DB_PATH=/abs/path/to/shared.sqlite

--- a/fastapi_backend/.env.example
+++ b/fastapi_backend/.env.example
@@ -1,2 +1,4 @@
 SAP_USER=your_user
 SAP_PASS=your_password
+# Absolute path to the shared SQLite database
+DB_PATH=/path/to/shared.sqlite

--- a/fastapi_backend/README.md
+++ b/fastapi_backend/README.md
@@ -15,6 +15,13 @@ pip install -r requirements.txt
 uvicorn main:app --reload
 ```
 
+Create a `.env` file in this directory and set `DB_PATH` to the absolute
+location of the shared SQLite database. Example:
+
+```env
+DB_PATH=/absolute/path/to/shared.sqlite
+```
+
 ### Endpoints
 
 - `/tools/{service_name}` - return an OpenAPI JSON spec for a single service

--- a/fastapi_backend/main.py
+++ b/fastapi_backend/main.py
@@ -8,9 +8,19 @@ from .metadata_store import MetadataStore
 from .endpoint_generator import generate_routers
 from .openapi_customizer import custom_openapi
 
+# Load environment variables from `.env` once during import so
+# `os.getenv` picks up values before the FastAPI application is created.
+ENV_PATH = os.path.join(os.path.dirname(__file__), ".env")
+load_dotenv(dotenv_path=ENV_PATH)
 
-def create_app(db_path: str = "../shared.sqlite") -> FastAPI:
-    load_dotenv(dotenv_path=os.path.join(os.path.dirname(__file__), ".env"))
+# Default to the shared database in the repository root, but use an
+# absolute path so the app can run from any location.
+DEFAULT_DB_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "shared.sqlite")
+)
+
+
+def create_app(db_path: str = DEFAULT_DB_PATH) -> FastAPI:
     store = MetadataStore(db_path)
     app = FastAPI()
     services = store.get_active_services()
@@ -44,4 +54,5 @@ def create_app(db_path: str = "../shared.sqlite") -> FastAPI:
     return app
 
 
-app = create_app(os.getenv("DB_PATH", "../shared.sqlite"))
+DB_PATH = os.getenv("DB_PATH", DEFAULT_DB_PATH)
+app = create_app(DB_PATH)


### PR DESCRIPTION
## Summary
- load environment variables before building the FastAPI app
- use an absolute path for the shared sqlite database
- document DB_PATH usage and provide sample values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e7ff499ac832b971fbfc03ab14549