### PR TITLE
Improve OData FastAPI bridge

### DIFF
--- a/fastapi_backend/README.md
+++ b/fastapi_backend/README.md
@@ -2,7 +2,8 @@
 
 This backend reads OData service metadata from the shared SQLite database and
 exposes dynamic endpoints for each active service. The resulting OpenAPI
-definitions can be consumed directly by LLM agents.
+definitions conform to version **3.1** and can be consumed directly by LLM
+agents.
 
 ## Running
 

--- a/fastapi_backend/endpoint_generator.py
+++ b/fastapi_backend/endpoint_generator.py
@@ -1,15 +1,41 @@
+"""Generate FastAPI routers based on OData metadata."""
+
+from __future__ import annotations
+
 from typing import Iterable
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 
 from .metadata_parser import parse_metadata
+from .odata_invoker import call_odata_service
 
 
-def _create_list_route(entity_name: str):
-    async def list_entities():
-        return []
+def _create_invoke_route(service: dict, entity: dict):
+    service_name = service.get("name") or service.get("service_name")
+    base_url = service.get("service_url") or service.get("service_base_url")
 
-    list_entities.__name__ = f"list_{entity_name}"
-    return list_entities
+    async def invoke(
+        top: int | None = Query(None, alias="$top", ge=1),
+        skip: int | None = Query(None, alias="$skip", ge=0),
+        filter_: str | None = Query(None, alias="$filter"),
+        select: str | None = Query(None, alias="$select"),
+        orderby: str | None = Query(None, alias="$orderby"),
+    ):
+        params = {}
+        if top is not None:
+            params["$top"] = top
+        if skip is not None:
+            params["$skip"] = skip
+        if filter_ is not None:
+            params["$filter"] = filter_
+        if select is not None:
+            params["$select"] = select
+        if orderby is not None:
+            params["$orderby"] = orderby
+
+        return await call_odata_service(service_name, entity["name"], params, base_url)
+
+    invoke.__name__ = f"invoke_{service_name}_{entity['name']}"
+    return invoke
 
 
 def generate_routers(services: Iterable[dict]) -> Iterable[APIRouter]:
@@ -17,14 +43,14 @@ def generate_routers(services: Iterable[dict]) -> Iterable[APIRouter]:
     for svc in services:
         meta = parse_metadata(svc.get("metadata_xml", svc.get("metadata", "")))
         name = svc.get("name") or svc.get("service_name")
-        router = APIRouter(prefix=f"/{name.strip('/')}")
+        router = APIRouter()
         for entity in meta.get("entities", []):
-            route = _create_list_route(entity["name"])
+            route = _create_invoke_route(svc, entity)
             router.add_api_route(
-                f"/{entity['name']}",
+                f"/invoke/{name}/{entity['name']}",
                 route,
                 methods=["GET"],
-                summary=f"List {entity['name']}",
+                summary=f"Invoke {entity['name']} from {name}",
                 tags=[name],
             )
         routers.append(router)

--- a/fastapi_backend/main.py
+++ b/fastapi_backend/main.py
@@ -1,10 +1,8 @@
 import os
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 from fastapi.openapi.utils import get_openapi
 from dotenv import load_dotenv
-
-from .odata_invoker import call_odata_service
 
 from .metadata_store import MetadataStore
 from .endpoint_generator import generate_routers
@@ -44,21 +42,9 @@ def create_app(db_path: str = DEFAULT_DB_PATH) -> FastAPI:
             description=svc.get("description") or "",
             routes=temp.routes,
         )
+        schema["openapi"] = "3.1.0"
         return JSONResponse(schema)
 
-    @app.get("/invoke/{service_name}/{entity}")
-    async def invoke(service_name: str, entity: str, request: Request):
-        svc = service_map.get(service_name)
-        if not svc:
-            raise HTTPException(status_code=404, detail="Service not found")
-
-        params = dict(request.query_params)
-        target_service = svc.get("service_name") or svc.get("name")
-        try:
-            data = await call_odata_service(target_service, entity, params)
-        except HTTPException as exc:
-            raise HTTPException(status_code=500, detail=exc.detail)
-        return JSONResponse(data)
 
     app.openapi = lambda: custom_openapi(app)
     return app

--- a/fastapi_backend/metadata_parser.py
+++ b/fastapi_backend/metadata_parser.py
@@ -1,12 +1,28 @@
-"""Utility functions for parsing OData $metadata documents."""
+"""Utility functions for parsing OData ``$metadata`` documents."""
+
+from __future__ import annotations
 
 from typing import Any, Dict, List
 
 import xmltodict
 
 
+def _extract_version(edmx: Dict[str, Any]) -> str:
+    """Return ``v2`` or ``v4`` based on the EDMX version attribute."""
+
+    version = (edmx.get("@Version") or "").split(".")[0]
+    if version == "4":
+        return "v4"
+    return "v2"
+
+
 def parse_metadata(text: str) -> Dict[str, Any]:
-    """Parse an OData metadata XML string into a simplified dict."""
+    """Parse an OData metadata XML string into a simplified dictionary.
+
+    The returned structure contains the OData version and a list of entity
+    definitions with their properties. Only a subset of the metadata is
+    extracted as required by the dynamic endpoint generator.
+    """
 
     try:
         doc = xmltodict.parse(text)
@@ -16,6 +32,9 @@ def parse_metadata(text: str) -> Dict[str, Any]:
     edmx = doc.get("edmx:Edmx") or doc.get("Edmx")
     if not edmx:
         return {}
+
+    version = _extract_version(edmx)
+
     dataservices = edmx.get("edmx:DataServices") or edmx.get("DataServices")
     if not dataservices:
         return {}
@@ -24,7 +43,8 @@ def parse_metadata(text: str) -> Dict[str, Any]:
     if not isinstance(schemas, list):
         schemas = [schemas]
 
-    entities: List[Dict[str, str]] = []
+    entities: List[Dict[str, Any]] = []
+
     for schema in schemas:
         container = schema.get("EntityContainer")
         if not container:
@@ -32,9 +52,46 @@ def parse_metadata(text: str) -> Dict[str, Any]:
         sets = container.get("EntitySet") or []
         if not isinstance(sets, list):
             sets = [sets]
+
+        # Map entity type name to its property definitions
+        entity_types = schema.get("EntityType") or []
+        if not isinstance(entity_types, list):
+            entity_types = [entity_types]
+        type_map = {et.get("@Name"): et for et in entity_types}
+
         for es in sets:
             name = es.get("@Name")
-            if name:
-                entities.append({"name": name})
+            etype = es.get("@EntityType")
+            if not name or not etype:
+                continue
+            et_name = etype.split(".")[-1]
+            et_def = type_map.get(et_name, {})
+            props = et_def.get("Property") or []
+            if not isinstance(props, list):
+                props = [props]
+            properties = []
+            for prop in props:
+                properties.append(
+                    {
+                        "name": prop.get("@Name"),
+                        "type": prop.get("@Type"),
+                        "filterable": prop.get("sap:filterable", "true") != "false",
+                        "label": prop.get("sap:label"),
+                        "maxlength": prop.get("@MaxLength"),
+                        "nullable": prop.get("@Nullable", "true") != "false",
+                    }
+                )
 
-    return {"entities": entities}
+            keys = []
+            key_def = et_def.get("Key", {})
+            refs = key_def.get("PropertyRef") or []
+            if not isinstance(refs, list):
+                refs = [refs]
+            for ref in refs:
+                key_name = ref.get("@Name")
+                if key_name:
+                    keys.append(key_name)
+
+            entities.append({"name": name, "properties": properties, "keys": keys})
+
+    return {"entities": entities, "version": version}

--- a/fastapi_backend/openapi_customizer.py
+++ b/fastapi_backend/openapi_customizer.py
@@ -1,3 +1,5 @@
+"""Utilities for producing a customised OpenAPI schema."""
+
 from fastapi.openapi.utils import get_openapi
 
 
@@ -10,5 +12,7 @@ def custom_openapi(app):
         description="Dynamically generated API from OData services",
         routes=app.routes,
     )
+    # Advertise OpenAPI 3.1 for improved schema support
+    openapi_schema["openapi"] = "3.1.0"
     app.openapi_schema = openapi_schema
     return app.openapi_schema

--- a/tests/test_fastapi_openapi.py
+++ b/tests/test_fastapi_openapi.py
@@ -49,4 +49,4 @@ def test_openapi_contains_entity_path():
         from fastapi_backend.main import app
         client = TestClient(app)
         schema = client.get("/openapi.json").json()
-        assert "/demo/Products" in schema["paths"]
+        assert "/invoke/demo/Products" in schema["paths"]


### PR DESCRIPTION
## Summary
- parse more metadata details and expose OData version
- generate /invoke routes with query parameters
- switch OpenAPI output to version 3.1
- update invoker to log final URL
- update tests for new paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb88d467c832b838703b65dad9e4c